### PR TITLE
Deploy to vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__/
 # IDE & OS specific
 .DS_Store
 .vscode/
+.vercel


### PR DESCRIPTION
Add `.vercel` to `.gitignore` to prevent Vercel-related configuration files from being committed to the repository during deployment setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-958cbf6a-368f-4abf-bcbd-9d5b2eae1544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-958cbf6a-368f-4abf-bcbd-9d5b2eae1544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

